### PR TITLE
Reuse IRI ssl if exists, allow playbook rerun via gosc

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
      * [GoShimmer Web](#goshimmer-web)
      * [Spam Test](#spam-test)
      * [See the statusscreen](#see-the-statusscreen)
+   * [Appendix](#appendix)
+     * [Install Alongside IRI-Playbook](#install-alongside-iri-playbook)
    * [Donations](#donations)
 <!--te-->
 
@@ -24,7 +26,7 @@
 
 Tested on the following operating systems:
 
-* CentOS 7
+* CentOS 7.x
 * Ubuntu 16/18.04LTS
 * Debian 9.5 and 10
 * Raspbian 9.9 and 10 (Tested with Raspberry Pi 4 - 4GB RAM)
@@ -180,6 +182,18 @@ Please refer to this article on how to use `screen` (you might need to install i
 ## Update the run-screen script or gosc
 
 To update any scripts provided by this playbook simply use `gosc` and select to update gosc and scripts option from the menu.
+
+# Appendix
+
+## Install Alongside IRI-Playbook
+
+It is possible to run this installation on an IRI-playbook node. You must have enough RAM and CPU power to accommodate both.
+
+A few notes:
+
+* This has only been tested in the case where you already have a Dockerized IRI-playbook node and run this installer afterwards.
+* GoShimmer-playbook re-uses IRI's HTTPS configuration (SSL certificate)
+* You will also be able to access the web services using the user you have configured for IRI
 
 # Donations
 

--- a/roles/goshimmer/files/gosc
+++ b/roles/goshimmer/files/gosc
@@ -13,7 +13,7 @@ fi
 clear
 
 : "${EDITOR:=nano}"
-VERSION_TEMP=0.0.3
+VERSION_TEMP=0.0.4
 __VERSION__=${VERSION_TEMP}
 
 : "${GOSHIMMER_BRANCH:=master}"
@@ -550,6 +550,38 @@ function services() {
     esac
 }
 
+### Rerun playbook installation ###
+function rerun_playbook() {
+
+    if (whiptail --title "Rerun Playbook Method" \
+                 --yesno "Sometimes you may want to rerun the entire installation if you think something has changed and you want to try to reset the node to its initial state.\nThere are two options:\n\n1. simply rerun the installation\n2. use the override method: it will reset any configurations you may have configured manually.\n\nIf you would like to use the override method choose Yes else choose No for normal rerun.\n" \
+                 --defaultno \
+             18 $WIDTH) then
+        local OVERWRITE=yes
+    else
+        local OVERWRITE=no
+    fi
+
+    if ! (whiptail --title "Rerun Playbook Confirm" \
+                   --yesno "This option will allow you to rerun the entire installation.\nUsing override method: $OVERWRITE\n\nWould you like to proceed?\n" \
+                   --defaultno \
+          12 $WIDTH) then
+        return
+    fi
+
+    verify_playbook
+    if [[ $? -ne 0 ]]; then
+        whiptail --title "Error!" \
+                 --msgbox "ERROR: Cannot rerun GoShimmer installation, unknown error." \
+                 8 $WIDTH
+        return 1
+    fi
+    cd /opt/goshimmer-playbook && ansible-playbook -i inventory site.yml -v -e "overwrite=$OVERWRITE"
+    [[ $? -ne 0 ]] && MSG="Rerunning the playbook installation failed!!! Check output above for errors." || MSG="Rerun finished successfully!"
+    pause "$MSG Press ENTER to return to menu."
+    clear
+}
+
 ### Configure files ###
 function configure_files_menu() {
     whiptail --title "GOSC v${__VERSION__} - Configure Files" \
@@ -601,7 +633,8 @@ function main_menu() {
     "b)" "Manage Services" \
     "c)" "Configure Files" \
     "d)" "View Per Processes Memory Usage" \
-    "e)" "Update GOSC and node scripts" \
+    "e)" "Rerun playbook installation" \
+    "f)" "Update GOSC and node scripts" \
     3>&1 1>&2 2>&3
 }
 
@@ -635,6 +668,11 @@ function run_main_menu() {
             ;;
 
         "e)")
+            rerun_playbook
+            run_main_menu
+            ;;
+
+        "f)")
             update_gosc
             run_main_menu
             ;;

--- a/roles/nginx/tasks/nginx.yml
+++ b/roles/nginx/tasks/nginx.yml
@@ -12,6 +12,17 @@
   tags: always
   when: ansible_distribution in debian_family_list
 
+- name: check if this is an IRI node for nginx ssl override config
+  stat:
+    path: "/opt/iri-playbook/group_vars/all/z-ssl-override.yml"
+  register: iri_ssl_override_config
+  tags: always
+
+- name: load override iri ssl override config variables
+  include_vars: "/opt/iri-playbook/group_vars/all/z-ssl-override.yml"
+  when: iri_ssl_override_config.stat.exists == True
+  tags: always
+
 - name: add user to run nginx as
   user:
     name: "{{ nginx_username }}"
@@ -36,6 +47,8 @@
   template:
     src: templates/nginx.service.j2
     dest: "{{ systemd_dir }}/nginx.service"
+    force: "{{ overwrite | default('no') }}"
+    backup: yes
   notify:
     - restart nginx
 
@@ -43,6 +56,8 @@
   template:
     src: templates/nginx.sysconfig.j2
     dest: "{{ config_dir }}/nginx"
+    force: "{{ overwrite | default('no') }}"
+    backup: yes
   notify:
     - restart nginx
 
@@ -51,6 +66,8 @@
     src: ../shared-files/validate_nginx_config.sh
     dest: /usr/local/bin/validate_nginx_config.sh
     mode: 0755
+    force: "{{ overwrite | default('no') }}"
+    backup: yes
 
 - name: ensure nginx config directories exist
   file:
@@ -74,6 +91,8 @@
     src: ../shared-files/ssl.cfg.j2
     dest: /etc/nginx/conf.d/ssl.cfg
     validate: "/usr/local/bin/validate_nginx_config.sh -t %s -d ssl.cfg"
+    force: "{{ overwrite | default('no') }}"
+    backup: yes
   notify:
     - restart nginx
   tags:


### PR DESCRIPTION
* Make it possible to re-use the SSL certificate from an already install iri-playbook node
* Add an option in the `gosc` menu to re-run the playbook installation
* Notes in README